### PR TITLE
fix: remove indentation from email template that appeared in output

### DIFF
--- a/wp-content/plugins/bd4d/template-parts/auto-reply.php
+++ b/wp-content/plugins/bd4d/template-parts/auto-reply.php
@@ -18,25 +18,25 @@ Many thanks,
 <?php else : ?>
 Hello, and thank you for joining the Better Deal for Data community!
 
-	<?php if ( $supporter ) : ?>
-We’re excited to welcome you to the movement to unlock the full potential of data to serve society, and add your name to our growing list of public supporters as part of our Coalition of the Willing.
-	<?php else : ?>
-We’re excited to welcome you to the movement to unlock the full potential of data to serve society.
-	<?php endif; ?>
+<?php if ( $supporter ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent -- Email template, indentation appears in output. ?>
+We're excited to welcome you to the movement to unlock the full potential of data to serve society, and add your name to our growing list of public supporters as part of our Coalition of the Willing.
+<?php else : // phpcs:ignore Generic.WhiteSpace.ScopeIndent ?>
+We're excited to welcome you to the movement to unlock the full potential of data to serve society.
+<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent ?>
 
-	<?php if ( $newsletter && ! $supporter ) : ?>
+<?php if ( $newsletter && ! $supporter ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent -- Email template, indentation appears in output. ?>
 This message is to confirm that you have subscribed to our email updates via our website. If you wish to unsubscribe from our email updates, please reply to this email with the word "Unsubscribe."
 
-We’d love to hear your feedback, questions, or stories about data! You can reach us at info@bd4d.org.
-	<?php elseif ( ! $newsletter && $supporter ) : ?>
-This message is to confirm that we have your permission to display your name and affiliation on our website. If you choose to sign up for email updates in the future, or if you have feedback, questions, or a data story to share, please send us a message at info@bd4d.org. We’d love to hear from you!
-	<?php elseif ( $newsletter && $supporter ) : ?>
+We'd love to hear your feedback, questions, or stories about data! You can reach us at info@bd4d.org.
+<?php elseif ( ! $newsletter && $supporter ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent ?>
+This message is to confirm that we have your permission to display your name and affiliation on our website. If you choose to sign up for email updates in the future, or if you have feedback, questions, or a data story to share, please send us a message at info@bd4d.org. We'd love to hear from you!
+<?php elseif ( $newsletter && $supporter ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent ?>
 This message is to confirm:
 • that we have your permission to display your name and affiliation on our website; and
 • that you have subscribed to our email updates via our website. If you wish to unsubscribe from our email updates, please reply to this email with the word "Unsubscribe."
 
-We’d love to hear your feedback, questions, or stories about data! You can reach us at info@bd4d.org.
-	<?php endif; ?>
+We'd love to hear your feedback, questions, or stories about data! You can reach us at info@bd4d.org.
+<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent ?>
 
 All the best,
 <?php endif; ?>


### PR DESCRIPTION
The tabs added for PHPCS compliance were appearing as whitespace in the plain text email output. Use inline phpcs:ignore comments instead to suppress the indentation warnings while keeping the template output clean.
