### PR TITLE
docs: update README version to 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A WordPress plugin by Tech Matters that provides a contact/newsletter subscription form with Airtable integration.
 
 **Website:** https://bd4d.org/
-**Version:** 1.0.3
+**Version:** 1.0.5
 **License:** GPL-2.0-or-later
 
 ## Features


### PR DESCRIPTION
The README header still read 1.0.3; the plugin is now 1.0.5 (`bd4d.php` / `BD4D_VERSION`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)